### PR TITLE
Update package.json to avoid resolution error

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "devDependencies": {
     "@rollup/plugin-commonjs": "^23.0.2",
     "@rollup/plugin-node-resolve": "^15.0.1",
+    "@rollup/plugin-terser": "0.2.1",
     "concurrently": "^7.5.0",
     "electron": "^21.2.0",
     "electron-builder": "^23.6.0",
@@ -40,7 +41,6 @@
     "rollup-plugin-css-only": "^4.2.0",
     "rollup-plugin-livereload": "^2.0.5",
     "rollup-plugin-svelte": "^7.1.0",
-    "rollup-plugin-terser": "^7.0.2",
     "sirv-cli": "^2.0.2",
     "svelte": "^3.52.0",
     "wait-on": "^6.0.1"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,7 +2,7 @@ import svelte from 'rollup-plugin-svelte';
 import commonjs from '@rollup/plugin-commonjs';
 import resolve from '@rollup/plugin-node-resolve';
 import livereload from 'rollup-plugin-livereload';
-import { terser } from 'rollup-plugin-terser';
+import terser from '@rollup/plugin-terser';
 import css from 'rollup-plugin-css-only';
 
 const production = !process.env.ROLLUP_WATCH;


### PR DESCRIPTION
This fixes #23 and is necessary because:
``` bash
warning rollup-plugin-terser@7.0.2: This package has been deprecated and is no longer maintained. Please use @rollup/plugin-terser
```